### PR TITLE
bugfix with command line parameters, 'h' and 'r' where used twice

### DIFF
--- a/from-udp/from-udp.hs
+++ b/from-udp/from-udp.hs
@@ -59,15 +59,15 @@ optParser = Options
               <> help "Window width. Default is 1024."
               ))
           <*> optional (option auto (
-                 long "height" 
-              <> short 'h' 
-              <> metavar "HEIGHT" 
+                 long "vertSize" 
+              <> short 'v' 
+              <> metavar "VERTSIZEHEIGHT" 
               <> help "Window height. Default is 480."
               ))
           <*> optional (option auto (
-                 long "rows" 
-              <> short 'r' 
-              <> metavar "ROWS" 
+                 long "lines" 
+              <> short 'l' 
+              <> metavar "LINES" 
               <> help "Number of rows in waterfall. Default is 1000."
               ))
           <*> optional (option parseColorMap (

--- a/waterfall/waterfall.hs
+++ b/waterfall/waterfall.hs
@@ -79,15 +79,15 @@ optParser = Options
               <> help "Window width. Default is 1024."
               ))
           <*> optional (option auto (
-                 long "height" 
-              <> short 'h' 
-              <> metavar "HEIGHT" 
+                 long "vertSize" 
+              <> short 'v' 
+              <> metavar "VERTSIZE" 
               <> help "Window height. Default is 480."
               ))
           <*> optional (option auto (
-                 long "rows" 
-              <> short 'r' 
-              <> metavar "ROWS" 
+                 long "lines" 
+              <> short 'l' 
+              <> metavar "LINES" 
               <> help "Number of rows in waterfall. Default is 1000."
               ))
           <*> optional (option parseColorMap (
@@ -121,3 +121,6 @@ doIt Options{..} = do
 
 main = execParser opt >>= exceptT putStrLn return . doIt
 
+
+
+db20 x = 20 * log x / (log 10)


### PR DESCRIPTION
-h was used for figure hight, but is already used fro 'help'
-r was used for 'rows' and also for sampling rate